### PR TITLE
Use Buffer.from explicitly when using zlib

### DIFF
--- a/lib/diagram-encoder.js
+++ b/lib/diagram-encoder.js
@@ -5,7 +5,7 @@ const contract = require('./contract');
 const support = require('./support');
 
 function encode(diagram) {
-    return deflateSync(diagram, { level: 9 }).toString('base64url');
+    return deflateSync(Buffer.from(diagram), { level: 9 }).toString('base64url');
 }
 function generateUrl(entrypoint, lang, imgType, diagram) {
 

--- a/lib/obs/marp-it-kroki.js
+++ b/lib/obs/marp-it-kroki.js
@@ -38,7 +38,7 @@ const marpKrokiPlugin = (md) => {
             const [lang] = info.split(/(\s+)/g)
 
             if (krokiLangs.includes(lang)) {
-                const data = deflateSync(tokens[idx].content).toString('base64url')
+                const data = deflateSync(Buffer.from(tokens[idx].content)).toString('base64url')
 
                 // <marp-auto-scaling> is working only with Marp Core v3
                 return `<p><marp-auto-scaling data-downscale-only><img src="${entrypoint}${lang}/svg/${data}"/></marp-auto-scaling></p>`


### PR DESCRIPTION
# Problem:
Using `markdown-it-kroki` inside an obsidian marp plugin fails to compress the diagram properly and produces 400 error on kroki

# Desired Result
Diagrams show up properly on obsidian marp plugin

# Cause:
To compile obsidian plugins for use in both mobile and desktop, the plugins needs to be packed for web only.
The packed `zlib-browserify` is using pako which [does not support compressing strings](https://github.com/nodeca/pako/issues/254), the proposed change solves that issue by adding Buffer.from.

# Further information:
the default browserify buffer module does not support base64url, so I'm using an alternative from feross (specifically pr [314](https://github.com/feross/buffer/pull/314))
I didn't want to add extra noise by adding more changes to this plugin by modifying the base64url as well.



